### PR TITLE
chore: rebuild generated source bundles

### DIFF
--- a/core/bundles/applied-intelligence-app-source.json
+++ b/core/bundles/applied-intelligence-app-source.json
@@ -1,4 +1,25 @@
 {
+  "design": {
+    "theme": "dark",
+    "colors": {
+      "background": "#08111f",
+      "surface": "#0d1b2a",
+      "primary": "#3aa0ff",
+      "glowBlue": "#4cc9f0",
+      "glowGreen": "#00ff9c",
+      "glowOrange": "#ff9f1c",
+      "glowPurple": "#9b5de5",
+      "glowRed": "#ff4d4d"
+    },
+    "agents": {
+      "AI-Connect": "#00ff9c",
+      "AI-Trace": "#3aa0ff",
+      "AI-CIS": "#ff9f1c",
+      "AI-ROI": "#4cc9f0",
+      "AI-Case": "#9b5de5",
+      "AI-RMA": "#ff4d4d"
+    }
+  },
   "system": {
     "name": "Applied Intelligence",
     "slug": "applied-intelligence",

--- a/core/bundles/applied-intelligence-website-source.json
+++ b/core/bundles/applied-intelligence-website-source.json
@@ -1,4 +1,25 @@
 {
+  "design": {
+    "theme": "dark",
+    "colors": {
+      "background": "#08111f",
+      "surface": "#0d1b2a",
+      "primary": "#3aa0ff",
+      "glowBlue": "#4cc9f0",
+      "glowGreen": "#00ff9c",
+      "glowOrange": "#ff9f1c",
+      "glowPurple": "#9b5de5",
+      "glowRed": "#ff4d4d"
+    },
+    "agents": {
+      "AI-Connect": "#00ff9c",
+      "AI-Trace": "#3aa0ff",
+      "AI-CIS": "#ff9f1c",
+      "AI-ROI": "#4cc9f0",
+      "AI-Case": "#9b5de5",
+      "AI-RMA": "#ff4d4d"
+    }
+  },
   "projectName": "Applied Intelligence Website",
   "system": {
     "name": "Applied Intelligence",


### PR DESCRIPTION
### Motivation
- Regenerate the app and website source bundles so the latest build output (including design metadata) is reflected in the generated artifacts.

### Description
- Ran `npm run build:sources` which added a top-level `design` object (with `theme`, `colors`, and `agents` mappings) to both `core/bundles/applied-intelligence-app-source.json` and `core/bundles/applied-intelligence-website-source.json`.
- Only the two generated bundle files were changed and no other source files were modified.

### Testing
- Ran `npm run build:sources` and it completed successfully.
- Verified that only `core/bundles/applied-intelligence-app-source.json` and `core/bundles/applied-intelligence-website-source.json` were updated and contain the new `design` section.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb8092cb883238f549e91602ce05e)